### PR TITLE
fixed config saving state

### DIFF
--- a/CameraPlus/Config.cs
+++ b/CameraPlus/Config.cs
@@ -198,6 +198,9 @@ namespace CameraPlus
         {
             _saving = true;
             ConfigSerializer.SaveConfig(this, FilePath);
+            // sets saving back to false cause SaveConfig wont write the file at all if nothing has changed
+            // and if so the FileWatcher would not get triggered so saving would stuck at true
+            _saving = false;
         }
 
         public void Load()


### PR DESCRIPTION
resets the saving state of a config file correctly
if the plugin was started and reads its configs and saves it back, the SaveConfig method wont do anything at all to the config file, so the saving state was stuck at true, always returning out of the FileWatcher. before you had to change stuff twice to trigger the save state back and get the FileWatcher to do its job.