### PR TITLE
Update FOV description on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Edit that file to configure CameraPlus:
 
 | Parameter                   | Description                                                                                  |
 |-----------------------------|----------------------------------------------------------------------------------------------|
-| **fov**                     | Horizontal field of view of the camera                                                       |
+| **fov**                     | Vertical field of view of the camera                                                       |
 | **antiAliasing**            | Anti-aliasing setting for the camera (1, 2, 4 or 8 only)                                     |
 | **renderScale**             | The resolution scale of the camera relative to game window (similar to supersampling for VR) |
 | **positionSmooth**          | How much position should smooth **(SMALLER NUMBER = SMOOTHER)**                              |


### PR DESCRIPTION
According to the Unity docs, fieldOfView specifies the vertical fov.
https://docs.unity3d.com/ScriptReference/Camera-fieldOfView.html

I was trying to align the Kinect with the in-game camera, and had a lot of trouble until I tried setting the vertical FOV instead.